### PR TITLE
Add temporary endpoint for staging

### DIFF
--- a/app/controllers/discourse_sitepoint_api/support_controller.rb
+++ b/app/controllers/discourse_sitepoint_api/support_controller.rb
@@ -12,6 +12,13 @@ module DiscourseSitepointApi
       render json: {users: users}, status: 200
     end
 
+    # TODO only for staging testing - remove this after the fact!
+    def staging_email_tokens
+      user = User.find_by(email: params[:email])
+      user.email_tokens.each { |t| t.destroy }
+      render json: {email: user.email, email_tokens: user.reload.email_tokens}
+    end
+
   end
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 DiscourseSitepointApi::Engine.routes.draw do
   get "/daily_log_outs" => "support#daily_log_outs"
+  delete "/staging_email_tokens" => "support#staging_email_tokens"
 end
 


### PR DESCRIPTION
Temporarily allow admins to clear email tokens so we can deactivate/reactivate their accounts. So they can actually login and test on staging.